### PR TITLE
Allow search table names in mixed cases

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -309,7 +309,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function tablesExist($names)
+    public function tablesExist($names, bool $lowercase = true): bool
     {
         if (is_string($names)) {
             Deprecation::trigger(
@@ -320,9 +320,14 @@ abstract class AbstractSchemaManager
             );
         }
 
-        $names = array_map('strtolower', (array) $names);
+        $tableNames = $this->listTableNames();
 
-        return count($names) === count(array_intersect($names, array_map('strtolower', $this->listTableNames())));
+        if ($lowercase === true) {
+            $names      = array_map('strtolower', (array) $names);
+            $tableNames = array_map('strtolower', $tableNames);
+        }
+
+        return count($names) === count(array_intersect($names, $tableNames));
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->
<!-- Fill in the relevant information below to help triage your pull request. -->

<!-- Provide a summary of your change. -->
#### Summary

Updated pull request

Mysql / MariaDB / Persona allows to use the table name in different cases.

The table names might look like this:

UPPERCASETABLENAME
CamelCaseTableName
lowercasetablename
Titlecasetablename

However, the original implementation of the tablesExist() function searches for existing tables ONLY in lower case: by using the function:
'strtolower()'

$names = array_map('strtolower', (array) $names);

return count($names) === count(array_intersect($names, $tableNames));

The current pull request allows to search for table names in different registers/cases - upper-camel-lower-title-mixed.

Reverse compatibility - observed.
The function will give the correct result for any table names registers/cases - upper-camel-lower-title-mixed.

Thank you


